### PR TITLE
Fix Points Result

### DIFF
--- a/mud.config.ts
+++ b/mud.config.ts
@@ -113,7 +113,7 @@ export default defineWorld({
       type: "offchainTable",
     },
     PointsResult: {
-      key: ["id"],
+      key: ["id", "pointsId"],
       schema: {
         id: "uint256",
         player: "address",

--- a/src/codegen/tables/PointsResult.sol
+++ b/src/codegen/tables/PointsResult.sol
@@ -22,7 +22,6 @@ import { EncodeArray } from "@latticexyz/store/src/tightcoder/EncodeArray.sol";
 
 struct PointsResultData {
     address player;
-    int16 pointsId;
     uint32 points;
 }
 
@@ -32,20 +31,21 @@ library PointsResult {
     ResourceId constant _tableId = ResourceId.wrap(0x6f740000000000000000000000000000506f696e7473526573756c7400000000);
 
     FieldLayout constant _fieldLayout =
-        FieldLayout.wrap(0x001a030014020400000000000000000000000000000000000000000000000000);
+        FieldLayout.wrap(0x0018020014040000000000000000000000000000000000000000000000000000);
 
-    // Hex-encoded key schema of (uint256)
-    Schema constant _keySchema = Schema.wrap(0x002001001f000000000000000000000000000000000000000000000000000000);
-    // Hex-encoded value schema of (address, int16, uint32)
-    Schema constant _valueSchema = Schema.wrap(0x001a030061210300000000000000000000000000000000000000000000000000);
+    // Hex-encoded key schema of (uint256, int16)
+    Schema constant _keySchema = Schema.wrap(0x002202001f210000000000000000000000000000000000000000000000000000);
+    // Hex-encoded value schema of (address, uint32)
+    Schema constant _valueSchema = Schema.wrap(0x0018020061030000000000000000000000000000000000000000000000000000);
 
     /**
      * @notice Get the table's key field names.
      * @return keyNames An array of strings with the names of key fields.
      */
     function getKeyNames() internal pure returns (string[] memory keyNames) {
-        keyNames = new string[](1);
+        keyNames = new string[](2);
         keyNames[0] = "id";
+        keyNames[1] = "pointsId";
     }
 
     /**
@@ -53,10 +53,9 @@ library PointsResult {
      * @return fieldNames An array of strings with the names of value fields.
      */
     function getFieldNames() internal pure returns (string[] memory fieldNames) {
-        fieldNames = new string[](3);
+        fieldNames = new string[](2);
         fieldNames[0] = "player";
-        fieldNames[1] = "pointsId";
-        fieldNames[2] = "points";
+        fieldNames[1] = "points";
     }
 
     /**
@@ -76,9 +75,10 @@ library PointsResult {
     /**
      * @notice Set player.
      */
-    function setPlayer(uint256 id, address player) internal {
-        bytes32[] memory _keyTuple = new bytes32[](1);
+    function setPlayer(uint256 id, int16 pointsId, address player) internal {
+        bytes32[] memory _keyTuple = new bytes32[](2);
         _keyTuple[0] = bytes32(uint256(id));
+        _keyTuple[1] = bytes32(uint256(int256(pointsId)));
 
         StoreSwitch.setStaticField(_tableId, _keyTuple, 0, abi.encodePacked((player)), _fieldLayout);
     }
@@ -86,64 +86,48 @@ library PointsResult {
     /**
      * @notice Set player.
      */
-    function _setPlayer(uint256 id, address player) internal {
-        bytes32[] memory _keyTuple = new bytes32[](1);
+    function _setPlayer(uint256 id, int16 pointsId, address player) internal {
+        bytes32[] memory _keyTuple = new bytes32[](2);
         _keyTuple[0] = bytes32(uint256(id));
+        _keyTuple[1] = bytes32(uint256(int256(pointsId)));
 
         StoreCore.setStaticField(_tableId, _keyTuple, 0, abi.encodePacked((player)), _fieldLayout);
     }
 
     /**
-     * @notice Set pointsId.
+     * @notice Set points.
      */
-    function setPointsId(uint256 id, int16 pointsId) internal {
-        bytes32[] memory _keyTuple = new bytes32[](1);
+    function setPoints(uint256 id, int16 pointsId, uint32 points) internal {
+        bytes32[] memory _keyTuple = new bytes32[](2);
         _keyTuple[0] = bytes32(uint256(id));
+        _keyTuple[1] = bytes32(uint256(int256(pointsId)));
 
-        StoreSwitch.setStaticField(_tableId, _keyTuple, 1, abi.encodePacked((pointsId)), _fieldLayout);
-    }
-
-    /**
-     * @notice Set pointsId.
-     */
-    function _setPointsId(uint256 id, int16 pointsId) internal {
-        bytes32[] memory _keyTuple = new bytes32[](1);
-        _keyTuple[0] = bytes32(uint256(id));
-
-        StoreCore.setStaticField(_tableId, _keyTuple, 1, abi.encodePacked((pointsId)), _fieldLayout);
+        StoreSwitch.setStaticField(_tableId, _keyTuple, 1, abi.encodePacked((points)), _fieldLayout);
     }
 
     /**
      * @notice Set points.
      */
-    function setPoints(uint256 id, uint32 points) internal {
-        bytes32[] memory _keyTuple = new bytes32[](1);
+    function _setPoints(uint256 id, int16 pointsId, uint32 points) internal {
+        bytes32[] memory _keyTuple = new bytes32[](2);
         _keyTuple[0] = bytes32(uint256(id));
+        _keyTuple[1] = bytes32(uint256(int256(pointsId)));
 
-        StoreSwitch.setStaticField(_tableId, _keyTuple, 2, abi.encodePacked((points)), _fieldLayout);
-    }
-
-    /**
-     * @notice Set points.
-     */
-    function _setPoints(uint256 id, uint32 points) internal {
-        bytes32[] memory _keyTuple = new bytes32[](1);
-        _keyTuple[0] = bytes32(uint256(id));
-
-        StoreCore.setStaticField(_tableId, _keyTuple, 2, abi.encodePacked((points)), _fieldLayout);
+        StoreCore.setStaticField(_tableId, _keyTuple, 1, abi.encodePacked((points)), _fieldLayout);
     }
 
     /**
      * @notice Set the full data using individual values.
      */
-    function set(uint256 id, address player, int16 pointsId, uint32 points) internal {
-        bytes memory _staticData = encodeStatic(player, pointsId, points);
+    function set(uint256 id, int16 pointsId, address player, uint32 points) internal {
+        bytes memory _staticData = encodeStatic(player, points);
 
         EncodedLengths _encodedLengths;
         bytes memory _dynamicData;
 
-        bytes32[] memory _keyTuple = new bytes32[](1);
+        bytes32[] memory _keyTuple = new bytes32[](2);
         _keyTuple[0] = bytes32(uint256(id));
+        _keyTuple[1] = bytes32(uint256(int256(pointsId)));
 
         StoreSwitch.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData);
     }
@@ -151,14 +135,15 @@ library PointsResult {
     /**
      * @notice Set the full data using individual values.
      */
-    function _set(uint256 id, address player, int16 pointsId, uint32 points) internal {
-        bytes memory _staticData = encodeStatic(player, pointsId, points);
+    function _set(uint256 id, int16 pointsId, address player, uint32 points) internal {
+        bytes memory _staticData = encodeStatic(player, points);
 
         EncodedLengths _encodedLengths;
         bytes memory _dynamicData;
 
-        bytes32[] memory _keyTuple = new bytes32[](1);
+        bytes32[] memory _keyTuple = new bytes32[](2);
         _keyTuple[0] = bytes32(uint256(id));
+        _keyTuple[1] = bytes32(uint256(int256(pointsId)));
 
         StoreCore.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData, _fieldLayout);
     }
@@ -166,14 +151,15 @@ library PointsResult {
     /**
      * @notice Set the full data using the data struct.
      */
-    function set(uint256 id, PointsResultData memory _table) internal {
-        bytes memory _staticData = encodeStatic(_table.player, _table.pointsId, _table.points);
+    function set(uint256 id, int16 pointsId, PointsResultData memory _table) internal {
+        bytes memory _staticData = encodeStatic(_table.player, _table.points);
 
         EncodedLengths _encodedLengths;
         bytes memory _dynamicData;
 
-        bytes32[] memory _keyTuple = new bytes32[](1);
+        bytes32[] memory _keyTuple = new bytes32[](2);
         _keyTuple[0] = bytes32(uint256(id));
+        _keyTuple[1] = bytes32(uint256(int256(pointsId)));
 
         StoreSwitch.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData);
     }
@@ -181,14 +167,15 @@ library PointsResult {
     /**
      * @notice Set the full data using the data struct.
      */
-    function _set(uint256 id, PointsResultData memory _table) internal {
-        bytes memory _staticData = encodeStatic(_table.player, _table.pointsId, _table.points);
+    function _set(uint256 id, int16 pointsId, PointsResultData memory _table) internal {
+        bytes memory _staticData = encodeStatic(_table.player, _table.points);
 
         EncodedLengths _encodedLengths;
         bytes memory _dynamicData;
 
-        bytes32[] memory _keyTuple = new bytes32[](1);
+        bytes32[] memory _keyTuple = new bytes32[](2);
         _keyTuple[0] = bytes32(uint256(id));
+        _keyTuple[1] = bytes32(uint256(int256(pointsId)));
 
         StoreCore.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData, _fieldLayout);
     }
@@ -196,12 +183,10 @@ library PointsResult {
     /**
      * @notice Decode the tightly packed blob of static data using this table's field layout.
      */
-    function decodeStatic(bytes memory _blob) internal pure returns (address player, int16 pointsId, uint32 points) {
+    function decodeStatic(bytes memory _blob) internal pure returns (address player, uint32 points) {
         player = (address(Bytes.getBytes20(_blob, 0)));
 
-        pointsId = (int16(uint16(Bytes.getBytes2(_blob, 20))));
-
-        points = (uint32(Bytes.getBytes4(_blob, 22)));
+        points = (uint32(Bytes.getBytes4(_blob, 20)));
     }
 
     /**
@@ -219,15 +204,16 @@ library PointsResult {
         pure
         returns (PointsResultData memory _table)
     {
-        (_table.player, _table.pointsId, _table.points) = decodeStatic(_staticData);
+        (_table.player, _table.points) = decodeStatic(_staticData);
     }
 
     /**
      * @notice Delete all data for given keys.
      */
-    function deleteRecord(uint256 id) internal {
-        bytes32[] memory _keyTuple = new bytes32[](1);
+    function deleteRecord(uint256 id, int16 pointsId) internal {
+        bytes32[] memory _keyTuple = new bytes32[](2);
         _keyTuple[0] = bytes32(uint256(id));
+        _keyTuple[1] = bytes32(uint256(int256(pointsId)));
 
         StoreSwitch.deleteRecord(_tableId, _keyTuple);
     }
@@ -235,9 +221,10 @@ library PointsResult {
     /**
      * @notice Delete all data for given keys.
      */
-    function _deleteRecord(uint256 id) internal {
-        bytes32[] memory _keyTuple = new bytes32[](1);
+    function _deleteRecord(uint256 id, int16 pointsId) internal {
+        bytes32[] memory _keyTuple = new bytes32[](2);
         _keyTuple[0] = bytes32(uint256(id));
+        _keyTuple[1] = bytes32(uint256(int256(pointsId)));
 
         StoreCore.deleteRecord(_tableId, _keyTuple, _fieldLayout);
     }
@@ -246,8 +233,8 @@ library PointsResult {
      * @notice Tightly pack static (fixed length) data using this table's schema.
      * @return The static data, encoded into a sequence of bytes.
      */
-    function encodeStatic(address player, int16 pointsId, uint32 points) internal pure returns (bytes memory) {
-        return abi.encodePacked(player, pointsId, points);
+    function encodeStatic(address player, uint32 points) internal pure returns (bytes memory) {
+        return abi.encodePacked(player, points);
     }
 
     /**
@@ -256,16 +243,8 @@ library PointsResult {
      * @return The lengths of the dynamic fields (packed into a single bytes32 value).
      * @return The dynamic (variable length) data, encoded into a sequence of bytes.
      */
-    function encode(
-        address player,
-        int16 pointsId,
-        uint32 points
-    )
-        internal
-        pure
-        returns (bytes memory, EncodedLengths, bytes memory)
-    {
-        bytes memory _staticData = encodeStatic(player, pointsId, points);
+    function encode(address player, uint32 points) internal pure returns (bytes memory, EncodedLengths, bytes memory) {
+        bytes memory _staticData = encodeStatic(player, points);
 
         EncodedLengths _encodedLengths;
         bytes memory _dynamicData;
@@ -276,9 +255,10 @@ library PointsResult {
     /**
      * @notice Encode keys as a bytes32 array using this table's field layout.
      */
-    function encodeKeyTuple(uint256 id) internal pure returns (bytes32[] memory) {
-        bytes32[] memory _keyTuple = new bytes32[](1);
+    function encodeKeyTuple(uint256 id, int16 pointsId) internal pure returns (bytes32[] memory) {
+        bytes32[] memory _keyTuple = new bytes32[](2);
         _keyTuple[0] = bytes32(uint256(id));
+        _keyTuple[1] = bytes32(uint256(int256(pointsId)));
 
         return _keyTuple;
     }

--- a/src/libraries/LibPoints.sol
+++ b/src/libraries/LibPoints.sol
@@ -29,7 +29,7 @@ library LibPoints {
     {
         uint32 points = getPoints(playWord, filledWord, start, direction, bounds);
         LibPlayer.incrementPoints(player, points);
-        PointsResult.set(playResultId, player, -1, points);
+        PointsResult.set({ id: playResultId, player: player, pointsId: -1, points: points });
         return points;
     }
 
@@ -91,7 +91,7 @@ library LibPoints {
             if (buildsOnPlayers[i] != address(0)) {
                 address player = buildsOnPlayers[i];
                 LibPlayer.incrementPoints(player, rewardPoints);
-                PointsResult.set(playResultId, player, int16(uint16(i)), rewardPoints);
+                PointsResult.set({ id: playResultId, player: player, pointsId: int16(uint16(i)), points: rewardPoints });
             }
         }
     }

--- a/worlds.json
+++ b/worlds.json
@@ -16,8 +16,8 @@
     "blockNumber": 6720499
   },
   "17069": {
-    "address": "0x823c05a53854e16c6faaab21bd63027611258abb",
-    "blockNumber": 380860
+    "address": "0xa8fd20dd1e154590b61b649ea57109e3a3507971",
+    "blockNumber": 603227
   },
   "31337": {
     "address": "0x4f4ddafbc93cf8d11a253f21ddbcf836139efdec"


### PR DESCRIPTION
- add `pointsId` as a composite key to the `PointsResult` offchain table used to emit events to track points per move on the frontend
- previously, the only key was `id`, which is unique per move, but the result was getting "overwritten" when multiple points were given out per move
