### PR TITLE
fix: ignore src/codegen during forge fmt

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,7 +8,7 @@
   quote_style = "double"
   tab_width = 4
   wrap_comments = true
-
+  ignore = ["src/codegen/**/*"]
 
 [profile.default]
   solc_version = "0.8.24"


### PR DESCRIPTION
I noticed the spacing and import order thrashing a lot when looking through commits. This should mitigate that.